### PR TITLE
fix: update mirrorng to 59.0.0

### DIFF
--- a/Assets/Mirror/Websocket/package.json
+++ b/Assets/Mirror/Websocket/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/MirrorNG/MirrorNG_Websocket.git"
     },
     "dependencies": {
-        "com.mirrorng.mirrorng": "43.3.2",
+        "com.mirrorng.mirrorng": "59.0.0",
         "com.cysharp.unitask": "2.0.36"
     },
     "samples": [


### PR DESCRIPTION
Hi, I found that package.json refer to 43.3.2, so that I encountered build error.
This error could be avoided by adding latest com.mirrorng.mirrorng explicitly.
If something is wrong or intended, feel free close.